### PR TITLE
Display players before map in activity

### DIFF
--- a/src/main/handlers/status_check.py
+++ b/src/main/handlers/status_check.py
@@ -38,7 +38,7 @@ class StatusCheck:
                 self.maintenance = True
                 return discord.Status.dnd, discord.Game('maintenance')
             else:
-                game_str = f'{data["map"]} | {data["players"]} player' + ('s' if data["players"] != 1 else '')
+                game_str = f'{data["players"]} player' + ('s' if data["players"] != 1 else '') + f' | {data["map"]}'
                 self.maintenance = False
                 self.failed_checks = 0
                 return discord.Status.online, discord.Game(name=game_str)

--- a/src/main/handlers/status_check.py
+++ b/src/main/handlers/status_check.py
@@ -38,7 +38,7 @@ class StatusCheck:
                 self.maintenance = True
                 return discord.Status.dnd, discord.Game('maintenance')
             else:
-                game_str = f'{data["players"]} player' + ('s' if data["players"] != 1 else '') + f' | {data["map"]}'
+                game_str = f'{data["players"]} player{"s" if data["players"] != 1 else ""} | {data["map"]}'
                 self.maintenance = False
                 self.failed_checks = 0
                 return discord.Status.online, discord.Game(name=game_str)


### PR DESCRIPTION
Number of players (which is the more important information) is being hidden when the map name is very long.